### PR TITLE
cron-descriptor 1.4.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cron-descriptor" %}
-{% set version = "1.2.24" %}
+{% set version = "1.4.5" %}
 
 
 package:
@@ -7,13 +7,13 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/cron_descriptor-{{ version }}.tar.gz
-  sha256: b0d4d1637d7f26e322c0fb4018aea6028b5ba5ea2e8c228231e2870cbfcef2c0
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
+  sha256: f51ce4ffc1d1f2816939add8524f206c376a42c87a5fca3091ce26725b3b1bca
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
-  skip: True  # [py<36]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: True  # [py<38]
 
 requirements:
   host:
@@ -35,8 +35,12 @@ test:
 about:
   home: https://github.com/Salamek/cron-descriptor
   summary: A Python library that converts cron expressions into human readable strings.
+  description: A Python library that converts cron expressions into human readable strings.
   license: MIT
   license_file: LICENSE
+  license_family: MIT
+  doc_url: https://github.com/Salamek/cron-descriptor
+  dev_url: https://github.com/Salamek/cron-descriptor
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-5704](https://anaconda.atlassian.net/browse/PKG-5704)
- [Upstream repository](https://github.com/Salamek/cron-descriptor/tree/1.4.5)
- [Upstream changelog/diff](https://github.com/Salamek/cron-descriptor/releases)

### Explanation of changes:

- Update version
- Cleanup recipe
- Linter fixes


[PKG-5704]: https://anaconda.atlassian.net/browse/PKG-5704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ