### PR TITLE
cron-descriptor 2.1.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cron-descriptor" %}
-{% set version = "1.4.5" %}
+{% set version = "2.1.0" %}
 
 
 package:
@@ -8,12 +8,13 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
-  sha256: f51ce4ffc1d1f2816939add8524f206c376a42c87a5fca3091ce26725b3b1bca
+  sha256: ecddb8b2f6c5286398949aaefe185364666af74f33b01877c61378e1fd4e38e6
 
 build:
   number: 0
+  noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: True  # [py<38]
+  skip: True  # [py<39]
 
 requirements:
   host:
@@ -23,6 +24,7 @@ requirements:
     - python
   run:
     - python
+    - typing_extensions
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,6 @@ source:
 
 build:
   number: 0
-  noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   skip: True  # [py<39]
 


### PR DESCRIPTION
**Links:**
- Jira: https://anaconda.atlassian.net/browse/PKG-15720
- Dev/home: https://github.com/Salamek/cron-descriptor
- conda-forge: https://github.com/conda-forge/cron-descriptor-feedstock
- PyPI: https://pypi.org/project/cron-descriptor/2.1.0
- PyPI Inspector: https://inspector.pypi.io/project/cron-descriptor/2.1.0

**Changes:**
- Update cron-descriptor 1.4.5 -> 2.1.0
- Add `noarch: python`
- Add `typing_extensions` runtime dependency
- Update skip selector to `py<39`

**Notes:**
- Major version bump (1->2); pure Python, noarch, no downstream rebuilds needed